### PR TITLE
docs: Move readme vars to variables section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The following setup is supported:
 
 ## Variables
 
-To run the solution, a number of variables need to be added. These will be used for building or pulling the Docker image and running it.
+To run the solution, a number of variables need to be added. These will be used for building or pulling the Docker image and
+running it.
 
 ### Shell Variables
 


### PR DESCRIPTION
Updated readme to not require the IMAGE_NAME, IMAGE_TAG and DEVICE_IP variables to both be in the .env file and added as shell variables. Also added IMAGE_TAG to more places where it should be.
