### PR TITLE
Disabled dependent libs build to reduce build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,14 @@ ENV CC=/usr/bin/gcc-5
 ENV CXX=/usr/bin/g++-5
 
 RUN <<EOF
-cmake .. -DBUILD_GSTREAMER_PLUGIN=TRUE
+# Building dependent libs is OFF as the required libs compatible with 
+# target arch like curl, openssl, log4cplus, gstreamer are installed via apt-get
+cmake .. -DBUILD_DEPENDENCIES=OFF -DBUILD_GSTREAMER_PLUGIN=TRUE
 make
 EOF
 
 FROM $ARCH/ubuntu:18.04
-
+#
 COPY --from=base /opt/app/amazon-kinesis-video-streams-producer-sdk-cpp/ /opt/app/amazon-kinesis-video-streams-producer-sdk-cpp/
 
 WORKDIR /opt/app/amazon-kinesis-video-streams-producer-sdk-cpp/build/


### PR DESCRIPTION
### Describe your changes

Build time for target architectures is taking longer time

### Issue ticket number and link

- Added a compile flag NOT to build dependent libs as they are available from apt install

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
