### PR TITLE
Push images to ghcr

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,8 +2,8 @@ name: Build and Push Kinesis Video Stream Application Image
 
 on:
   push:
-#    tags:
-#      - "*"
+    tags:
+      - "*"
 
 jobs:
   build_and_push:

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ perform image and or video analytics.
         - [Container Build Variables](#container-build-variables)
         - [Container Runtime Variables](#container-runtime-variables)
     - [Install](#install)
-        - [From GitHub Container Registry](#from-github-container-registry)
+        - [From Docker Hub](#from-docker-hub)
         - [Build Locally](#build-locally)
 - [Option 2: AWS IoT Certificate](#option-2-aws-iot-certificate)
     - [Prerequisites](#prerequisites)
     - [Creating the Certificate Files](#creating-the-certificate-files)
     - [Install](#install-1)
-        - [From GitHub Container Registry](#from-github-container-registry-1)
+        - [From Docker Hub](#from-docker-hub-1)
         - [Build Locally](#build-locally-1)
 - [Run on the Camera](#run-on-the-camera)
     - [Save and Load the Image to the Camera](#save-and-load-the-image-to-the-camera)
@@ -69,7 +69,7 @@ running it.
 Add the image name as a shell variable so that it can be reused:
 
 ```sh
-IMAGE_NAME=ghcr.io/axiscommunications/kinesis-video-stream-application
+IMAGE_NAME=axisecp/kinesis-video-stream-application
 ```
 
 Also, add the image tag:
@@ -101,12 +101,12 @@ AWS_SECRET_ACCESS_KEY=<AWS secret key>
 
 ### Install
 
-The image can be retrieved by either pulling it from GitHub Container Registry, or by building
+The image can be retrieved by either pulling it from Docker Hub, or by building
 it locally.
 
-#### From GitHub Container Registry
+#### From Docker Hub
 
-Get the Docker image by pulling it from GitHub Container Registry:
+Get the Docker image by pulling it from Docker Hub:
 
 ```sh
 docker pull ${IMAGE_NAME}:${IMAGE_TAG}
@@ -212,7 +212,7 @@ If the prerequisites are set up by following the
 
 There's two options for how to run an image using the generated certificate. Either by building the certificate into an image or by generation temporary credentials from the certificate.
 
-#### From GitHub Container Registry
+#### From Docker Hub
 
 With this option the image need **not** be rebuilt. To use this option the following steps needs to be performed:
 


### PR DESCRIPTION
Includes changes to the cd workflow and readme. Cd workflow pushes the images to GitHub Container Registry and readme has been updated corresponding to the changes in where the images can be found.