### PR TITLE
Handle SIGSEGV by restarting streaming process

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,5 @@ services:
       GST_PLUGIN_PATH: /opt/app/amazon-kinesis-video-streams-producer-sdk-cpp/build
       no_proxy: $DEVICE_IP
     command: /bin/sh "start_stream.sh"
+    restart: 'unless-stopped'
 

--- a/start_stream.sh
+++ b/start_stream.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-gst-launch-1.0 rtspsrc \
+gst-launch-1.0 --no-fault rtspsrc \
         location="rtsp://$DEVICE_USERNAME:$DEVICE_PASSWORD@$DEVICE_IP/axis-media/media.amp" short-header=TRUE ! rtph264depay ! h264parse ! video/x-h264 !kvssink stream-name="$AWS_KINESIS_STREAM_NAME" storage-size=512 \
         aws-region="$AWS_REGION"


### PR DESCRIPTION
### Describe your changes

When SIGSEGV error happens in GStreamer, it tries to run the debugger by default. This then fails, since the debugger is not installed and as a result, the process is not restarted, just keeps hanging. The streaming the stops.

The PR disables the default debugger and let's the process die. Then it is restarted by Docker.

Sample SIGSEGV error:
```
Caught SIGSEGV
exec gdb failed: No such file or directory
Spinning.  Please run 'gdb gst-launch-1.0 8' to continue debugging, Ctrl-C to quit, or Ctrl-\ to dump core.
```

### Issue ticket number and link

- Fixes #32

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
